### PR TITLE
Make the option params for store and wrapStore optional

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -8,7 +8,7 @@ export class Store<S = any, A extends redux.Action = redux.Action> {
    * Creates a new Proxy store
    * @param options An object of form {portName, state, extensionId}, where `portName` is a required string and defines the name of the port for state transition changes, `state` is the initial state of this store (default `{}`) `extensionId` is the extension id as defined by chrome when extension is loaded (default `''`)
    */
-  constructor(options: {
+  constructor(options?: {
     portName?: string,
     state?: any,
     extensionId?: string,
@@ -75,7 +75,7 @@ export class Store<S = any, A extends redux.Action = redux.Action> {
 
 export function wrapStore<S>(
   store: redux.Store<S>,
-  configuration: {
+  configuration?: {
     portName?: string,
     dispatchResponder?(dispatchResult: any, send: (response: any) => void): void,
     serializer?: Function,

--- a/src/store/Store.js
+++ b/src/store/Store.js
@@ -14,12 +14,21 @@ const backgroundErrPrefix = '\nLooks like there is an error in the background pa
   'You might want to inspect your background page for more details.\n';
 
 
+const defaultOpts = {
+  portName: DEFAULT_PORT_NAME,
+  state: {},
+  extensionId: null,
+  serializer: noop,
+  deserializer: noop,
+  patchStrategy: shallowDiff
+};
+
 class Store {
   /**
    * Creates a new Proxy store
    * @param  {object} options An object of form {portName, state, extensionId, serializer, deserializer, diffStrategy}, where `portName` is a required string and defines the name of the port for state transition changes, `state` is the initial state of this store (default `{}`) `extensionId` is the extension id as defined by browserAPI when extension is loaded (default `''`), `serializer` is a function to serialize outgoing message payloads (default is passthrough), `deserializer` is a function to deserialize incoming message payloads (default is passthrough), and patchStrategy is one of the included patching strategies (default is shallow diff) or a custom patching function.
    */
-  constructor({portName = DEFAULT_PORT_NAME, state = {}, extensionId = null, serializer = noop, deserializer = noop, patchStrategy = shallowDiff}) {
+  constructor({portName = defaultOpts.portName, state = defaultOpts.state, extensionId = defaultOpts.extensionId, serializer = defaultOpts.serializer, deserializer = defaultOpts.deserializer, patchStrategy = defaultOpts.patchStrategy} = defaultOpts) {
     if (!portName) {
       throw new Error('portName is required in options');
     }

--- a/src/wrap-store/wrapStore.js
+++ b/src/wrap-store/wrapStore.js
@@ -32,18 +32,26 @@ const promiseResponder = (dispatchResult, send) => {
     });
 };
 
+const defaultOpts = {
+  portName: DEFAULT_PORT_NAME,
+  dispatchResponder: promiseResponder,
+  serializer: noop,
+  deserializer: noop,
+  diffStrategy: shallowDiff
+};
+
 /**
  * Wraps a Redux store so that proxy stores can connect to it.
  * @param {Object} store A Redux store
  * @param {Object} options An object of form {portName, dispatchResponder, serializer, deserializer}, where `portName` is a required string and defines the name of the port for state transition changes, `dispatchResponder` is a function that takes the result of a store dispatch and optionally implements custom logic for responding to the original dispatch message,`serializer` is a function to serialize outgoing message payloads (default is passthrough), `deserializer` is a function to deserialize incoming message payloads (default is passthrough), and diffStrategy is one of the included diffing strategies (default is shallow diff) or a custom diffing function.
  */
 export default (store, {
-  portName = DEFAULT_PORT_NAME,
-  dispatchResponder,
-  serializer = noop,
-  deserializer = noop,
-  diffStrategy = shallowDiff
-}) => {
+  portName = defaultOpts.portName,
+  dispatchResponder = defaultOpts.dispatchResponder,
+  serializer = defaultOpts.serializer,
+  deserializer = defaultOpts.deserializer,
+  diffStrategy = defaultOpts.diffStrategy
+} = defaultOpts) => {
   if (!portName) {
     throw new Error('portName is required in options');
   }
@@ -55,11 +63,6 @@ export default (store, {
   }
   if (typeof diffStrategy !== 'function') {
     throw new Error('diffStrategy must be one of the included diffing strategies or a custom diff function');
-  }
-
-  // set dispatch responder as promise responder
-  if (!dispatchResponder) {
-    dispatchResponder = promiseResponder;
   }
 
   const browserAPI = getBrowserAPI();

--- a/test/Store.test.js
+++ b/test/Store.test.js
@@ -424,10 +424,8 @@ describe('Store', function () {
   });
 
   describe("when validating options", function () {
-    it('should throw an error if portName is not present', function () {
-      should.throws(() => {
-        new Store();
-      }, Error);
+    it('should use defaults if no options present', function () {
+      should.doesNotThrow(() => new Store());
     });
 
     it('should throw an error if serializer is not a function', function () {

--- a/test/wrapStore.test.js
+++ b/test/wrapStore.test.js
@@ -248,6 +248,10 @@ describe('wrapStore', function () {
       dispatch: sinon.spy(),
     };
 
+    it('should use defaults if no options present', function () {
+      should.doesNotThrow(() => wrapStore(store));
+    });
+
     it('should throw an error if serializer is not a function', function () {
       should.throws(() => {
         wrapStore(store, { portName, serializer: "abc" });


### PR DESCRIPTION
The option param was still required by the nature of how we were assigning defaults. I made it optional and cleaned up a little.