### PR TITLE
Add a response handler to the store ready messages to read lastError

### DIFF
--- a/src/wrap-store/wrapStore.js
+++ b/src/wrap-store/wrapStore.js
@@ -167,7 +167,7 @@ export default (store, {
     for(const tab of tabs){
       browserAPI.tabs.sendMessage(tab.id, {action: 'storeReady'});
     }
-  }, (response) => {
+  }, () => {
     if (chrome.runtime.lastError) {
       // do nothing - errors can be present
       // if no content script exists on reciever

--- a/src/wrap-store/wrapStore.js
+++ b/src/wrap-store/wrapStore.js
@@ -167,6 +167,11 @@ export default (store, {
     for(const tab of tabs){
       browserAPI.tabs.sendMessage(tab.id, {action: 'storeReady'});
     }
+  }, (response) => {
+    if (chrome.runtime.lastError) {
+      // do nothing - errors can be present
+      // if no content script exists on reciever
+    }
   });
 
   // For non-tab based


### PR DESCRIPTION
Fixes #209. When a message is sent to each tab explicitly in the store ready function, it will result in `lastError` being populated if no content script exists on the tab.

@alexelisenko Do you want to see if this change fixes the error for you? 