### PR TITLE
Resolving Redux/webext-redux Store typings compatibility.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -30,11 +30,11 @@ export class Store<S = any, A extends redux.Action = redux.AnyAction> {
   */
   ready<S>(cb: () => S): Promise<S>;
 
-    /**
-   * Subscribes a listener function for all state changes
-   * @param listener A listener function to be called when store state changes
-   * @return An unsubscribe function which can be called to remove the listener from state updates
-   */
+  /**
+ * Subscribes a listener function for all state changes
+ * @param listener A listener function to be called when store state changes
+ * @return An unsubscribe function which can be called to remove the listener from state updates
+ */
   subscribe(listener: () => void): () => void;
 
   /**
@@ -49,7 +49,7 @@ export class Store<S = any, A extends redux.Action = redux.AnyAction> {
    */
   patchState(difference: Array<any>): void;
 
-  
+
   /**
    * Stub function to stay consistent with Redux Store API. No-op.
    * @param nextReducer The reducer for the store to use instead.
@@ -71,6 +71,14 @@ export class Store<S = any, A extends redux.Action = redux.AnyAction> {
    * action response from the background page
    */
   dispatch<A>(data: A): A;
+
+  /**
+   * Interoperability point for observable/reactive libraries.
+   * @returns {observable} A minimal observable of state changes.
+   * For more information, see the observable proposal:
+   * https://github.com/tc39/proposal-observable
+   */
+  [Symbol.observable](): Observable<S>
 }
 
 export function wrapStore<S, A extends redux.Action = redux.AnyAction>(
@@ -92,3 +100,36 @@ export function applyMiddleware(
   store: Store,
   ...middleware: redux.Middleware[]
 ): Store;
+
+/**
+ * Function to remove listener added by `Store.subscribe()`.
+ */
+export interface Unsubscribe {
+  (): void
+}
+
+/**
+ * A minimal observable of state changes.
+ * For more information, see the observable proposal:
+ * https://github.com/tc39/proposal-observable
+ */
+export type Observable<T> = {
+  /**
+   * The minimal observable subscription method.
+   * @param {Object} observer Any object that can be used as an observer.
+   * The observer object should have a `next` method.
+   * @returns {subscription} An object with an `unsubscribe` method that can
+   * be used to unsubscribe the observable from the store, and prevent further
+   * emission of values from the observable.
+   */
+  subscribe: (observer: Observer<T>) => { unsubscribe: Unsubscribe }
+  [Symbol.observable](): Observable<T>
+}
+
+/**
+ * An Observer is used to receive data from an Observable, and is supplied as
+ * an argument to subscribe.
+ */
+export type Observer<T> = {
+  next?(value: T): void
+}


### PR DESCRIPTION
 - webext-redux is missing the following object definition in the Store.

        - [Symbol.observable](): Observable<S>

 - Adding it and other typing definitions dependencies.
 - The types are copied from the original redux index.d.ts file (redux v4.0.4)

 - This commit will solve - https://github.com/tshaddix/webext-redux/issues/235