### PR TITLE
Remove safetyHandler and safetyMessage

### DIFF
--- a/src/store/Store.js
+++ b/src/store/Store.js
@@ -49,8 +49,9 @@ class Store {
     this.browserAPI = getBrowserAPI();
     this.extensionId = extensionId; // keep the extensionId as an instance variable
     this.port = this.browserAPI.runtime.connect(this.extensionId, {name: portName});
-    this.safetyHandler = this.safetyHandler.bind(this);
-    this.safetyMessage = this.browserAPI.runtime.onMessage.addListener(this.safetyHandler);
+    // Remove safetyHandler and safetyMessage as the corresponding APIs are not accessible inside an iframe
+    // this.safetyHandler = this.safetyHandler.bind(this);
+    // this.safetyMessage = this.browserAPI.runtime.onMessage.addListener(this.safetyHandler);
     this.serializedPortListener = withDeserializer(deserializer)((...args) => this.port.onMessage.addListener(...args));
     this.serializedMessageSender = withSerializer(serializer)((...args) => this.browserAPI.runtime.sendMessage(...args), 1);
     this.listeners = [];
@@ -168,19 +169,19 @@ class Store {
     });
   }
 
-  safetyHandler(message){
-    if (message.action === 'storeReady'){
+  // safetyHandler(message){
+  //   if (message.action === 'storeReady'){
 
-      // Remove Saftey Listener
-      this.browserAPI.runtime.onMessage.removeListener(this.safetyHandler);
+  //     // Remove Saftey Listener
+  //     this.browserAPI.runtime.onMessage.removeListener(this.safetyHandler);
 
-      // Resolve if readyPromise has not been resolved.
-      if(!this.readyResolved) {
-        this.readyResolved = true;
-        this.readyResolve();
-      }
-    }
-  }
+  //     // Resolve if readyPromise has not been resolved.
+  //     if(!this.readyResolved) {
+  //       this.readyResolved = true;
+  //       this.readyResolve();
+  //     }
+  //   }
+  // }
 }
 
 export default Store;

--- a/src/wrap-store/wrapStore.js
+++ b/src/wrap-store/wrapStore.js
@@ -163,16 +163,20 @@ export default (store, {
   /**
    * Safety message to tabs for content scripts
    */
-  browserAPI.tabs.query({}, tabs => {
-    for(const tab of tabs){
-      browserAPI.tabs.sendMessage(tab.id, {action: 'storeReady'}, () => {
-        if (chrome.runtime.lastError) {
-          // do nothing - errors can be present
-          // if no content script exists on reciever
-        }
-      });
-    }
-  });
+  // Removed safety message as the proxy store inside the iframe cannot receive it,
+  // and also the code uses callbacks, which result in an unhandled error once
+  // the chrome APIs are promisified
+  
+  // browserAPI.tabs.query({}, tabs => {
+  //   for(const tab of tabs){
+  //     browserAPI.tabs.sendMessage(tab.id, {action: 'storeReady'}, () => {
+  //       if (chrome.runtime.lastError) {
+  //         // do nothing - errors can be present
+  //         // if no content script exists on reciever
+  //       }
+  //     });
+  //   }
+  // });
 
   // For non-tab based
   // TODO: Find use case for this. Ommiting until then.


### PR DESCRIPTION
Proxy store inside an iframe cannot access the appropriate Chrome APIs to handle non-port messages, thus we remove all safety messages to eliminate errors arising arising from this restriction.