### PR TITLE
Forward redux events to remote stores

### DIFF
--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -1,3 +1,7 @@
+// Message type for store action events from
+// background to Proxy Stores
+export const ACTION_TYPE = 'chromex.action';
+
 // Message type used for dispatch events
 // from the Proxy Stores to background
 export const DISPATCH_TYPE = 'chromex.dispatch';


### PR DESCRIPTION
Hey folks, thanks for a great package! I ran into the same [issue](https://github.com/tshaddix/webext-redux/issues/243) as a couple other people where I wasn't getting actions to trigger my side-effects on my remote stores. I added a redux middleware to the background store in `wrapStore` that drops every action into the message bus for the remote stores and re-dispatches them on the remote so they can get picked up by side-effects.

NB: I didn't think carefully about the ordering of messages here because it doesn't matter for my use case, but would probably be a good idea if you've got the time to think about when the actions and state patches arrive at the remote ;)