### PR TITLE
Add portName to 'storeReady' message

### DIFF
--- a/src/store/Store.js
+++ b/src/store/Store.js
@@ -171,7 +171,7 @@ class Store {
   }
 
   safetyHandler(message){
-    if (message.action === 'storeReady'){
+    if (message.action === 'storeReady' && message.portName === this.portName){
 
       // Remove Saftey Listener
       this.browserAPI.runtime.onMessage.removeListener(this.safetyHandler);

--- a/src/wrap-store/wrapStore.js
+++ b/src/wrap-store/wrapStore.js
@@ -165,7 +165,7 @@ export default (store, {
    */
   browserAPI.tabs.query({}, tabs => {
     for(const tab of tabs){
-      browserAPI.tabs.sendMessage(tab.id, {action: 'storeReady'}, () => {
+      browserAPI.tabs.sendMessage(tab.id, {action: 'storeReady', portName}, () => {
         if (chrome.runtime.lastError) {
           // do nothing - errors can be present
           // if no content script exists on reciever


### PR DESCRIPTION
First of all: thank you so much for this library ❤️ 

We have multiple redux stores that we want to sync. That works mostly great with the `portName` parameter. But we run into race conditions regarding the `storeReady` message: Whatever store is ready first, triggers a `storeReady` for all stores because the `storeReady` did not take the `portName` into consideration. 