### PR TITLE
Support customize browser api

### DIFF
--- a/src/store/Store.js
+++ b/src/store/Store.js
@@ -18,6 +18,7 @@ const defaultOpts = {
   portName: DEFAULT_PORT_NAME,
   state: {},
   extensionId: null,
+  browserAPI: null,
   serializer: noop,
   deserializer: noop,
   patchStrategy: shallowDiff
@@ -28,7 +29,15 @@ class Store {
    * Creates a new Proxy store
    * @param  {object} options An object of form {portName, state, extensionId, serializer, deserializer, diffStrategy}, where `portName` is a required string and defines the name of the port for state transition changes, `state` is the initial state of this store (default `{}`) `extensionId` is the extension id as defined by browserAPI when extension is loaded (default `''`), `serializer` is a function to serialize outgoing message payloads (default is passthrough), `deserializer` is a function to deserialize incoming message payloads (default is passthrough), and patchStrategy is one of the included patching strategies (default is shallow diff) or a custom patching function.
    */
-  constructor({portName = defaultOpts.portName, state = defaultOpts.state, extensionId = defaultOpts.extensionId, serializer = defaultOpts.serializer, deserializer = defaultOpts.deserializer, patchStrategy = defaultOpts.patchStrategy} = defaultOpts) {
+  constructor({
+    portName = defaultOpts.portName,
+    state = defaultOpts.state,
+    extensionId = defaultOpts.extensionId,
+    browserAPI = defaultOpts.browserAPI,
+    serializer = defaultOpts.serializer,
+    deserializer = defaultOpts.deserializer,
+    patchStrategy = defaultOpts.patchStrategy
+  } = defaultOpts) {
     if (!portName) {
       throw new Error('portName is required in options');
     }
@@ -46,7 +55,7 @@ class Store {
     this.readyResolved = false;
     this.readyPromise = new Promise(resolve => this.readyResolve = resolve);
 
-    this.browserAPI = getBrowserAPI();
+    this.browserAPI = browserAPI || getBrowserAPI();
     this.extensionId = extensionId; // keep the extensionId as an instance variable
     this.port = this.browserAPI.runtime.connect(this.extensionId, {name: portName});
     this.safetyHandler = this.safetyHandler.bind(this);

--- a/src/store/Store.js
+++ b/src/store/Store.js
@@ -27,7 +27,14 @@ const defaultOpts = {
 class Store {
   /**
    * Creates a new Proxy store
-   * @param  {object} options An object of form {portName, state, extensionId, serializer, deserializer, diffStrategy}, where `portName` is a required string and defines the name of the port for state transition changes, `state` is the initial state of this store (default `{}`) `extensionId` is the extension id as defined by browserAPI when extension is loaded (default `''`), `serializer` is a function to serialize outgoing message payloads (default is passthrough), `deserializer` is a function to deserialize incoming message payloads (default is passthrough), and patchStrategy is one of the included patching strategies (default is shallow diff) or a custom patching function.
+   * @param {object} options An object of form {portName, state, extensionId, browserAPI, serializer, deserializer, diffStrategy}
+   * @param {string} options.portName A required string and defines the name of the port for state transition changes
+   * @param {object} options.state The initial state of this store (default `{}`)
+   * @param {string} options.extensionId The extension id as defined by browserAPI when extension is loaded (default `''`)
+   * @param {object} options.browserAPI A browser api (default is global browser api)
+   * @param {function} options.serializer A function to serialize outgoing message payloads (default is passthrough)
+   * @param {function} options.deserializer A function to deserialize incoming message payloads (default is passthrough)
+   * @param {function} options.patchStrategy One of the included patching strategies or a custom patching function (default is shallow diff)
    */
   constructor({
     portName = defaultOpts.portName,


### PR DESCRIPTION
## Goal

As a extension development, if we need to use `webext-redux` on certain website which has already define a global variables named `browser`, it would make it not work because the `getBrowserAPI` function looks for a global browser api.

Therefore, add option named `browserAPI` for development to give the target `browserAPI` and avoid to looks for a global browser api

## Changes

* Add option named `browserAPI` and default is `null` which fallback to `getBrowserAPI` function
* Update comment of options