### PR TITLE
Pass complete serialized errors between background and proxy store

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "webext-redux",
-  "version": "2.1.9",
+  "version": "2.1.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "webext-redux",
-  "version": "2.1.10",
+  "version": "2.1.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "webext-redux",
+  "name": "webext-redux-w-errors",
   "version": "2.1.11",
   "lockfileVersion": 1,
   "requires": true,
@@ -4294,6 +4294,14 @@
       "integrity": "sha512-PqpAxfrEhlSUWge8dwIp4tZnQ25DIOthpiaHNIthsjEFQD6EvqUKUDM7L8O2rShkFccYo1VjJR0coWfNkCubRw==",
       "dev": true
     },
+    "serialize-error": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
+      "integrity": "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==",
+      "requires": {
+        "type-fest": "^0.13.1"
+      }
+    },
     "serialize-javascript": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.9.1.tgz",
@@ -4892,6 +4900,11 @@
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
       "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
       "dev": true
+    },
+    "type-fest": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
+      "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg=="
     },
     "typedarray": {
       "version": "0.0.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "webext-redux",
-  "version": "2.1.7",
+  "version": "2.1.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "webext-redux",
-  "version": "2.1.8",
+  "version": "2.1.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "webext-redux-w-errors",
-  "version": "2.1.11",
+  "version": "2.1.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webext-redux-w-errors",
-  "version": "2.1.8",
+  "version": "2.1.9",
   "description": "A set of utilities for building Redux applications in Web Extensions.",
   "main": "lib/index.js",
   "typings": "./index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webext-redux-w-errors",
-  "version": "2.1.11",
+  "version": "2.1.12",
   "description": "A set of utilities for building Redux applications in Web Extensions.",
   "main": "lib/index.js",
   "typings": "./index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "webext-redux",
+  "name": "webext-redux-w-errors",
   "version": "2.1.7",
   "description": "A set of utilities for building Redux applications in Web Extensions.",
   "main": "lib/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webext-redux-w-errors",
-  "version": "2.1.10",
+  "version": "2.1.11",
   "description": "A set of utilities for building Redux applications in Web Extensions.",
   "main": "lib/index.js",
   "typings": "./index.d.ts",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
   "homepage": "https://github.com/tshaddix/webext-redux#readme",
   "dependencies": {
     "lodash.assignin": "^4.2.0",
-    "lodash.clonedeep": "^4.5.0"
+    "lodash.clonedeep": "^4.5.0",
+    "serialize-error": "^7.0.1"
   },
   "devDependencies": {
     "@babel/cli": "^7.2.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webext-redux-w-errors",
-  "version": "2.1.7",
+  "version": "2.1.8",
   "description": "A set of utilities for building Redux applications in Web Extensions.",
   "main": "lib/index.js",
   "typings": "./index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webext-redux-w-errors",
-  "version": "2.1.9",
+  "version": "2.1.10",
   "description": "A set of utilities for building Redux applications in Web Extensions.",
   "main": "lib/index.js",
   "typings": "./index.d.ts",

--- a/src/store/Store.js
+++ b/src/store/Store.js
@@ -156,7 +156,8 @@ class Store {
           const {error, value} = resp;
 
           if (error) {
-            const err = assignIn(new Error(error.message), error)
+            const err = assignIn(new Error(error.message), error);
+
             reject(err);
           } else {
             resolve(value && value.payload);

--- a/src/store/Store.js
+++ b/src/store/Store.js
@@ -157,7 +157,7 @@ class Store {
 
           if (error) {
             const err = new Error(error.message)
-            reject(assignIn(err, error));
+            reject(assignIn(error, err));
           } else {
             resolve(value && value.payload);
           }

--- a/src/store/Store.js
+++ b/src/store/Store.js
@@ -156,8 +156,9 @@ class Store {
           const {error, value} = resp;
 
           if (error) {
-            const err = new Error(error.message)
-            reject(assignIn(err, error));
+            const err = assignIn(new Error(error.message), error)
+            console.log(error.message, 'dispatch error', err)
+            reject(err);
           } else {
             resolve(value && value.payload);
           }

--- a/src/store/Store.js
+++ b/src/store/Store.js
@@ -160,9 +160,7 @@ class Store {
           const {error, value} = resp;
 
           if (error) {
-            const bgErr = new Error(`${backgroundErrPrefix}${error}`);
-
-            reject(assignIn(bgErr, error));
+            reject(error);
           } else {
             resolve(value && value.payload);
           }

--- a/src/store/Store.js
+++ b/src/store/Store.js
@@ -10,10 +10,6 @@ import { withSerializer, withDeserializer, noop } from "../serialization";
 import shallowDiff from '../strategies/shallowDiff/patch';
 import {getBrowserAPI} from '../util';
 
-const backgroundErrPrefix = '\nLooks like there is an error in the background page. ' +
-  'You might want to inspect your background page for more details.\n';
-
-
 const defaultOpts = {
   portName: DEFAULT_PORT_NAME,
   state: {},
@@ -160,7 +156,8 @@ class Store {
           const {error, value} = resp;
 
           if (error) {
-            reject(error);
+            const err = new Error(error.message)
+            reject(assignIn(err, error));
           } else {
             resolve(value && value.payload);
           }

--- a/src/store/Store.js
+++ b/src/store/Store.js
@@ -157,7 +157,6 @@ class Store {
 
           if (error) {
             const err = assignIn(new Error(error.message), error)
-            console.log(error.message, 'dispatch error', err)
             reject(err);
           } else {
             resolve(value && value.payload);

--- a/src/store/Store.js
+++ b/src/store/Store.js
@@ -157,7 +157,7 @@ class Store {
 
           if (error) {
             const err = new Error(error.message)
-            reject(assignIn(error, err));
+            reject(assignIn(err, error));
           } else {
             resolve(value && value.payload);
           }

--- a/src/wrap-store/wrapStore.js
+++ b/src/wrap-store/wrapStore.js
@@ -7,6 +7,7 @@ import {
 import { withSerializer, withDeserializer, noop } from "../serialization";
 import {getBrowserAPI} from '../util';
 import shallowDiff from '../strategies/shallowDiff/diff';
+import { serializeError } from 'serialize-error';
 
 /**
  * Responder for promisified results
@@ -26,7 +27,7 @@ const promiseResponder = (dispatchResult, send) => {
     .catch((err) => {
       console.error('error dispatching result:', err);
       send({
-        error: err,
+        error: serializeError(err),
         value: null
       });
     });

--- a/src/wrap-store/wrapStore.js
+++ b/src/wrap-store/wrapStore.js
@@ -26,7 +26,7 @@ const promiseResponder = (dispatchResult, send) => {
     .catch((err) => {
       console.error('error dispatching result:', err);
       send({
-        error: err.message,
+        error: err,
         value: null
       });
     });
@@ -81,7 +81,7 @@ export default (store, {
       try {
         dispatchResult = store.dispatch(action);
       } catch (e) {
-        dispatchResult = Promise.reject(e.message);
+        dispatchResult = Promise.reject(e);
         console.error(e);
       }
 


### PR DESCRIPTION
I've been facing the issue where `webext-redux` only allows you to `error.message` back to my content scripts in the case of an error in an aliased action. However my error objects contain other information, for example:
```
Error {
  message: 'this is a message',
  status: 400,
  code: 'CODE-001',
  result: { ... },
  stack: { ... },
}
```
This pull request will serialize all errors by default, the full error is then reconciled and rejected to the content-script that called the original dispatch function. You can test this PR with this npm module `webext-redux-w-errors@latest`.

First-time contributor, open to any feedback! 🙌