### PR TITLE
Reconnect to the port if not ready upon safety message

### DIFF
--- a/test/Store.test.js
+++ b/test/Store.test.js
@@ -145,13 +145,16 @@ describe("Store", function () {
       // mock onMessage listeners array
       const safetyListeners = [];
 
+      const disconnectSpy = sinon.spy();
       // override mock chrome API for this test
+
       self.chrome.runtime = {
         connect: () => {
           return {
             onMessage: {
               addListener: () => {},
             },
+            disconnect: disconnectSpy
           };
         },
         onMessage: {
@@ -177,26 +180,32 @@ describe("Store", function () {
 
       // make readyResolve() a spy function
       store.readyResolve = sinon.spy();
+      store.setupPort = sinon.spy();
 
       // send message
       l({ action: "storeReady", portName });
 
       safetyListeners.length.should.equal(0);
-      store.readyResolved.should.eql(true);
-      store.readyResolve.calledOnce.should.equal(true);
+      store.readyResolved.should.eql(false);
+      store.readyResolve.callCount.should.equal(0);
+      store.setupPort.callCount.should.equal(1);
+      disconnectSpy.callCount.should.equal(1);
     });
 
     it("should setup a safety listener per portName", function () {
       // mock onMessage listeners array
       const safetyListeners = [];
 
+      const disconnectSpy = sinon.spy();
       // override mock chrome API for this test
+
       self.chrome.runtime = {
         connect: () => {
           return {
             onMessage: {
               addListener: () => {},
             },
+            disconnect: disconnectSpy
           };
         },
         onMessage: {
@@ -224,26 +233,34 @@ describe("Store", function () {
 
       // make readyResolve() a spy function
       store.readyResolve = sinon.spy();
+      store.setupPort = sinon.spy();
       store2.readyResolve = sinon.spy();
+      store2.setupPort = sinon.spy();
 
       // send message for port 1
       l1({ action: "storeReady", portName });
       l2({ action: "storeReady", portName });
 
       safetyListeners.length.should.equal(1);
-      store.readyResolved.should.eql(true);
-      store.readyResolve.calledOnce.should.equal(true);
+      store.readyResolved.should.eql(false);
+      store.readyResolve.calledOnce.should.equal(false);
+      store.setupPort.calledOnce.should.equal(true);
       store2.readyResolved.should.eql(false);
       store2.readyResolve.calledOnce.should.equal(false);
+      store2.setupPort.calledOnce.should.equal(false);
+      disconnectSpy.callCount.should.equal(1);
 
       // send message for port 2
       l1({ action: "storeReady", portName: portName2 });
       l2({ action: "storeReady", portName: portName2 });
       safetyListeners.length.should.equal(0);
-      store.readyResolved.should.eql(true);
-      store.readyResolve.calledOnce.should.equal(true);
-      store2.readyResolved.should.eql(true);
-      store2.readyResolve.calledOnce.should.equal(true);
+      store.readyResolved.should.eql(false);
+      store.readyResolve.calledOnce.should.equal(false);
+      store.setupPort.calledOnce.should.equal(true);
+      store2.readyResolved.should.eql(false);
+      store2.readyResolve.calledOnce.should.equal(false);
+      store2.setupPort.calledOnce.should.equal(true);
+      disconnectSpy.callCount.should.equal(2);
     });
   });
 


### PR DESCRIPTION
## Overview
In situations where `wrapStore` is happening after the `Store` is created we do not currently call the onConnect listener which syncs initial state. The safety handler, however, will mark the store as ready and resolve the ready promise. This means that the content script will start using the store even though it has never synced with the background. In my use case this means that the content script is using the default `Store` state of `{}`. 

To resolve this, the safety handler (if the store is not ready) now triggers the `Store` to disconnect and then reconnect to the port. This will trigger the `onConnect` handler in the wrapped store and sync state as expected. 

## Alternatives
- I explored having the safety handler actually sync the state, but that potentially leaves the app in a state where the content script has initial state, but the background script has not necessarily set up a subscription to post messages to that port. Rather than implement a secondary handshake process, I thought reconnecting if the safety handler is used would be a simpler approach.

## Reproduction Steps
These are effectively the same as https://github.com/tshaddix/webext-redux/issues/106

I'm wrapping my `wrapStore` in a timeout, then reloading the extension + a page that sets up a Store in a content script. Basically this guarantees that the `Store` is set up before `wrapStore` happens.
```
setTimeout(() => {
  wrapStore(store, {
    portName: REDUX_PORT_NAME,
  });
}, 10000);
```