### PR TITLE
bind 'this' for getState and subscribe in Store constructor

### DIFF
--- a/src/store/Store.js
+++ b/src/store/Store.js
@@ -81,6 +81,8 @@ class Store {
     });
 
     this.dispatch = this.dispatch.bind(this); // add this context to dispatch
+    this.getState = this.getState.bind(this); // add this context to getState
+    this.subscribe = this.subscribe.bind(this); // add this context to subscribe
   }
 
   /**


### PR DESCRIPTION
This change adds 'this'-binding inside the Store constructor for `getState` and `subscribe`.
This fixes the `Uncaught TypeError: Cannot read properties of undefined (reading 'state')` when using webext-redux with newer versions of react-redux. 

Should fix https://github.com/tshaddix/webext-redux/issues/280 and https://github.com/tshaddix/webext-redux/issues/286 