### PR TITLE
Update Redux peer dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "babel-eslint": "^7.2.0",
         "eslint": "^4.18.2",
         "mocha": "^5.2.0",
-        "redux": "^4.0.4",
+        "redux": "5.0.1",
         "rollup": "^1.22.0",
         "rollup-plugin-babel": "^4.3.3",
         "rollup-plugin-commonjs": "^10.1.0",
@@ -3138,14 +3138,10 @@
       }
     },
     "node_modules/redux": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/redux/-/redux-4.0.4.tgz",
-      "integrity": "sha512-vKv4WdiJxOWKxK0yRoaK3Y4pxxB0ilzVx6dszU2W8wLxlb2yikRph4iV/ymtdJ6ZxpBLFbyrxklnT5yBbQSl3Q==",
-      "dev": true,
-      "dependencies": {
-        "loose-envify": "^1.4.0",
-        "symbol-observable": "^1.2.0"
-      }
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "dev": true
     },
     "node_modules/regenerate": {
       "version": "1.4.0",
@@ -3680,15 +3676,6 @@
       },
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/symbol-observable": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
-      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/table": {
@@ -6508,14 +6495,10 @@
       }
     },
     "redux": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/redux/-/redux-4.0.4.tgz",
-      "integrity": "sha512-vKv4WdiJxOWKxK0yRoaK3Y4pxxB0ilzVx6dszU2W8wLxlb2yikRph4iV/ymtdJ6ZxpBLFbyrxklnT5yBbQSl3Q==",
-      "dev": true,
-      "requires": {
-        "loose-envify": "^1.4.0",
-        "symbol-observable": "^1.2.0"
-      }
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "dev": true
     },
     "regenerate": {
       "version": "1.4.0",
@@ -6973,12 +6956,6 @@
       "requires": {
         "has-flag": "^3.0.0"
       }
-    },
-    "symbol-observable": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
-      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==",
-      "dev": true
     },
     "table": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "babel-eslint": "^7.2.0",
     "eslint": "^4.18.2",
     "mocha": "^5.2.0",
-    "redux": "^4.0.4",
+    "redux": "5.0.1",
     "rollup": "^1.22.0",
     "rollup-plugin-babel": "^4.3.3",
     "rollup-plugin-commonjs": "^10.1.0",
@@ -49,6 +49,6 @@
     "sinon": "^6.0.0"
   },
   "peerDependencies": {
-    "redux": ">= 3 <= 4"
+    "redux": ">= 3 <= 5"
   }
 }


### PR DESCRIPTION
This PR allows webext-redux to be installed next to redux@5. [Based on the changelog](https://redux.js.org/usage/migrations/migrating-rtk-2), the 5.0.0 update didn't include any changes that affect webext-redux.

Fixes #296 