### PR TITLE
Fix browser errors about async responses

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -19,9 +19,9 @@ jobs:
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
           cache: "npm"

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x]
+        node-version: [18.x, 20.x, 22.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:

--- a/index.d.ts
+++ b/index.d.ts
@@ -92,7 +92,6 @@ export class Store<S = any, A extends redux.Action = redux.AnyAction> {
 type WrapStore<S, A extends redux.Action = redux.AnyAction> = (
   store: redux.Store<S, A>,
   configuration?: {
-    channelName?: string;
     dispatchResponder?(
       dispatchResult: any,
       send: (response: any) => void
@@ -106,7 +105,9 @@ type WrapStore<S, A extends redux.Action = redux.AnyAction> = (
 export function createWrapStore<
   S,
   A extends redux.Action = redux.AnyAction
->(): WrapStore<S, A>;
+>(configuration?: {
+    channelName?: string;
+}): WrapStore<S, A>;
 
 export function alias(aliases: {
   [key: string]: (action: any) => any;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "webext-redux",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "webext-redux",
-      "version": "3.0.0",
+      "version": "4.0.0",
       "license": "MIT",
       "dependencies": {
         "lodash.assignin": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webext-redux",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "description": "A set of utilities for building Redux applications in Web Extensions.",
   "main": "lib/index.js",
   "typings": "./index.d.ts",

--- a/src/listener.js
+++ b/src/listener.js
@@ -1,8 +1,34 @@
-export const createDeferredListener = () => {
+/**
+ * Returns a function that can be passed as a listener callback to a browser
+ * API. The listener will queue events until setListener is called.
+ *
+ * @param {Function} filter - A function that filters messages to be handled by
+ * the listener. This is important to avoid telling the browser to expect an
+ * async response when the message is not intended for this listener.
+ *
+ * @example
+ * const filter = (message, sender, sendResponse) => {
+ *   return message.type === "my_type"
+ * }
+ *
+ * const { listener, setListener } = createDeferredListener(filter);
+ * chrome.runtime.onMessage.addListener(listener);
+ *
+ * // Later, define the listener to handle messages. Messages received
+ * // before this point are queued.
+ * setListener((message, sender, sendResponse) => {
+ *  console.log(message);
+ * });
+ */
+export const createDeferredListener = (filter) => {
   let resolve = () => {};
   const fnPromise = new Promise((resolve_) => (resolve = resolve_));
 
   const listener = (message, sender, sendResponse) => {
+    if (!filter(message, sender, sendResponse)) {
+      return;
+    }
+
     fnPromise.then((fn) => {
       fn(message, sender, sendResponse);
     });

--- a/test/listener.test.js
+++ b/test/listener.test.js
@@ -1,9 +1,14 @@
 import sinon from "sinon";
 import { createDeferredListener } from "../src/listener";
+import should from "should";
+
+const filterAny = () => {
+  return true;
+};
 
 describe("createDeferredListener", () => {
   it("queues calls to the listener", async () => {
-    const { setListener, listener } = createDeferredListener();
+    const { setListener, listener } = createDeferredListener(filterAny);
     const spy = sinon.spy();
 
     // Trigger a couple of events
@@ -17,6 +22,7 @@ describe("createDeferredListener", () => {
     listener("message3", "sender3", "sendResponse3");
     listener("message4", "sender4", "sendResponse4");
 
+    // Wait for promise queue to clear
     await Promise.resolve();
 
     spy.callCount.should.equal(4);
@@ -24,5 +30,29 @@ describe("createDeferredListener", () => {
     spy.getCall(1).args.should.eql(["message2", "sender2", "sendResponse2"]);
     spy.getCall(2).args.should.eql(["message3", "sender3", "sendResponse3"]);
     spy.getCall(3).args.should.eql(["message4", "sender4", "sendResponse4"]);
+  });
+
+  it("ignores messages that don't pass the filter", async () => {
+    const filter = (message) => {
+      return message === "message";
+    };
+
+    const { setListener, listener } = createDeferredListener(filter);
+    const spy = sinon.spy();
+
+    const result1 = listener("message", "sender", "sendResponse");
+    const result2 = listener("message2", "sender2", "sendResponse2");
+
+    result1.should.eql(true);
+    console.log(result2);
+    should(result2).eql(undefined);
+
+    setListener(spy);
+
+    // Wait for promise queue to clear
+    await Promise.resolve();
+
+    spy.callCount.should.equal(1);
+    spy.getCall(0).args.should.eql(["message", "sender", "sendResponse"]);
   });
 });

--- a/test/wrapStore.test.js
+++ b/test/wrapStore.test.js
@@ -88,9 +88,9 @@ describe('wrapStore', function () {
     });
 
     it('should dispatch actions received on onMessage to store', async function () {
-      const wrapStore = createWrapStore();
+      const wrapStore = createWrapStore({ channelName });
 
-      wrapStore(store, { channelName });
+      wrapStore(store);
       listeners.onMessage.forEach(l => l(message, sender, callback));
 
       await Promise.resolve();
@@ -106,9 +106,9 @@ describe('wrapStore', function () {
     });
 
     it('should not dispatch actions received on onMessage for other ports', function () {
-      const wrapStore = createWrapStore();
+      const wrapStore = createWrapStore({ channelName });
 
-      wrapStore(store, { channelName });
+      wrapStore(store);
       message.channelName = channelName + '2';
       listeners.onMessage.forEach(l => l(message, sender, callback));
 
@@ -117,9 +117,9 @@ describe('wrapStore', function () {
 
     it('should deserialize incoming messages correctly', async function () {
       const deserializer = sinon.spy(JSON.parse);
-      const wrapStore = createWrapStore();
+      const wrapStore = createWrapStore({ channelName });
 
-      wrapStore(store, { channelName, deserializer });
+      wrapStore(store, { deserializer });
       message.payload = JSON.stringify(payload);
       listeners.onMessage.forEach(l => l(message, sender, callback));
 
@@ -137,9 +137,9 @@ describe('wrapStore', function () {
 
     it('should not deserialize incoming messages for other ports', function () {
       const deserializer = sinon.spy(JSON.parse);
-      const wrapStore = createWrapStore();
+      const wrapStore = createWrapStore({ channelName });
 
-      wrapStore(store, { channelName, deserializer });
+      wrapStore(store, { deserializer });
       message.channelName = channelName + '2';
       message.payload = JSON.stringify(payload);
       listeners.onMessage.forEach(l => l(message, sender, callback));
@@ -172,9 +172,9 @@ describe('wrapStore', function () {
       .onThirdCall().returns(secondState);
 
     const serializer = (payload) => JSON.stringify(payload);
-    const wrapStore = createWrapStore();
+    const wrapStore = createWrapStore({ channelName });
 
-    wrapStore(store, { channelName, serializer });
+    wrapStore(store, { serializer });
 
     // Simulate a state update by calling subscribers
     subscribers.forEach(subscriber => subscriber());
@@ -223,9 +223,9 @@ describe('wrapStore', function () {
       type: 'FAKE_DIFF',
       oldObj, newObj
     }]);
-    const wrapStore = createWrapStore();
+    const wrapStore = createWrapStore({ channelName });
 
-    wrapStore(store, { channelName, diffStrategy });
+    wrapStore(store, { diffStrategy });
 
     // Simulate a state update by calling subscribers
     subscribers.forEach(subscriber => subscriber());
@@ -259,25 +259,25 @@ describe('wrapStore', function () {
 
     it('should throw an error if serializer is not a function', function () {
       should.throws(() => {
-        const wrapStore = createWrapStore();
+        const wrapStore = createWrapStore({ channelName });
 
-        wrapStore(store, { channelName, serializer: "abc" });
+        wrapStore(store, { serializer: "abc" });
       }, Error);
     });
 
     it('should throw an error if deserializer is not a function', function () {
       should.throws(() => {
-        const wrapStore = createWrapStore();
+        const wrapStore = createWrapStore({ channelName });
 
-        wrapStore(store, { channelName, deserializer: "abc" });
+        wrapStore(store, { deserializer: "abc" });
       }, Error);
     });
 
     it('should throw an error if diffStrategy is not a function', function () {
       should.throws(() => {
-        const wrapStore = createWrapStore();
+        const wrapStore = createWrapStore({ channelName });
 
-        wrapStore(store, { channelName, diffStrategy: "abc" });
+        wrapStore(store, { diffStrategy: "abc" });
       }, Error);
     });
   });
@@ -314,9 +314,9 @@ describe('wrapStore', function () {
           }
         }
       };
-      const wrapStore = createWrapStore();
+      const wrapStore = createWrapStore({ channelName });
 
-      wrapStore(store, { channelName });
+      wrapStore(store);
 
       tabResponders.length.should.equal(5);
     },


### PR DESCRIPTION
Fixes #303

The issue was the deferred listener helper would `return true` (telling the browser to expect an async response) for every message, even if the messages were not from the library. In `wrapStore()`, those messages would be ignored causing the browser to log an error:

> Error: A listener indicated an asynchronous response by returning true, but the message channel closed before a response was received

This is mostly harmless, but it's better to avoid the error. In this commit, `createDeferredListener()` now takes a `filter` function that determines if the message will be handled so that messages from outside the library can be ignored.

Unfortunately this requires a breaking change: moving the `channelName` argument to `createWrapStore()`. This is required since the filter function needs to know which channel to expect before `wrapStore()` is called. I'm hoping that most consumers don't pass `channelName` so this won't affect most apps.